### PR TITLE
Training the FlatCat model and tuning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ Before running the code, please install Morfessor 2.0 (http://morfessor.readthed
 ## Unsupervised Example
 Here we set the corpus weight parameter to 1.0. 
 The optimal value depends on the data set.
+
 `$ python Stemming_unsupervised.py 1.0 raw/en/ segmented/en/`
 
 ## Auto-tuning Example
 Here we use auto-tuning of the corpus weight parameter.
 The tuning parameter is the average length of morphs (all morphs including affixes, not just stems).
 In the example we set this to 3.5 characters.
+
 `$ python Stemming_autotune.py 3.5 raw/en/ segmented/en/`

--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@ This stemmer uses Morfessor 2.0 (Virpioja,et al. 2013) and Morfessor FlatCat 1.0
 * Stemming_unsupervised.py is the code for unsupervised stemming.
 * The sample data to be stemmed is in raw/en/ and raw/tr/.
 * The output will be stored in segmented/en/ and segmented/tr/ respectively.
+* In this example, the model is trained on the data to be stemmed. In practice you may want to train on larger data.
 
 ## Setup
 Before running the code, please install Morfessor 2.0 (http://morfessor.readthedocs.io/en/latest/installation.html) and Morfessor FlatCat 1.0.5 (http://morfessor-flatcat.readthedocs.io/en/latest/installation.html#installation-instructions).
 
-## Running Example
+## Unsupervised Example
+Here we set the corpus weight parameter to 1.0. 
+The optimal value depends on the data set.
 `$ python Stemming_unsupervised.py 1.0 raw/en/ segmented/en/`
 
+## Auto-tuning Example
+Here we use auto-tuning of the corpus weight parameter.
+The tuning parameter is the average length of morphs (all morphs including affixes, not just stems).
+In the example we set this to 3.5 characters.
+python Stemming_autotune.py 3.5 raw/en/ segmented/en/

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ The optimal value depends on the data set.
 Here we use auto-tuning of the corpus weight parameter.
 The tuning parameter is the average length of morphs (all morphs including affixes, not just stems).
 In the example we set this to 3.5 characters.
-python Stemming_autotune.py 3.5 raw/en/ segmented/en/
+`$ python Stemming_autotune.py 3.5 raw/en/ segmented/en/`

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ This stemmer uses Morfessor 2.0 (Virpioja,et al. 2013) and Morfessor FlatCat 1.0
 Before running the code, please install Morfessor 2.0 (http://morfessor.readthedocs.io/en/latest/installation.html) and Morfessor FlatCat 1.0.5 (http://morfessor-flatcat.readthedocs.io/en/latest/installation.html#installation-instructions).
 
 ## Running Example
-`$ python Stemming_unsupervised.py raw/en/ segmented/en/`
+`$ python Stemming_unsupervised.py 1.0 raw/en/ segmented/en/`
 

--- a/Stemming_autotune.py
+++ b/Stemming_autotune.py
@@ -1,0 +1,109 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import os
+import codecs
+import sys
+import morfessor
+import flatcat
+
+average_morph_length = float(sys.argv[1])
+input_dir = sys.argv[2]
+output_dir = sys.argv[3]
+
+def filetowordlist(path, sfx, output, output_freq):
+    filedict = {}
+    allwordlist = []
+    fw = codecs.open(output, 'w', encoding='utf-8')
+    for item in os.listdir(path):
+        if sfx in item:
+            wordlist = []
+            for line in codecs.open(path+item, 'r', encoding='utf-8'):
+                lines = line.strip().split()
+                for word in lines:
+                    wd = ''
+                    for letter in word:
+                        if letter.isalpha():
+                            wd = wd+letter
+                        else:
+                            wd = wd + ' '
+                    w = wd.split()
+                    for d in w:
+                        wordlist.append(d.lower())
+                        allwordlist.append(d.lower())
+                        fw.write(d.lower() + '\n')
+            filedict[item] = wordlist
+    print('counting word frequencies ...')
+    fw_freq = codecs.open(output_freq, 'w', encoding='utf-8')
+    for word in set(allwordlist):
+        fw_freq.write(str(allwordlist.count(word)) + ' ' + word + '\n')
+    return filedict, allwordlist
+
+print('loading and preprocessing data ...')
+files, allwordlist = filetowordlist(input_dir, '.txt', 'TempOut.txt', 'Freq.txt')
+
+def Base_SegModel(data, average_morph_length):
+    io = morfessor.MorfessorIO()
+    train_data = list(io.read_corpus_file(data))
+    baseline_model = morfessor.BaselineModel(corpusweight=1.0)
+    updater = morfessor.baseline.MorphLengthCorpusWeight(average_morph_length)
+    baseline_model.set_corpus_weight_updater(updater)
+    baseline_model.load_data(train_data, count_modifier=lambda x: 1)
+    baseline_model.train_batch()
+
+    return baseline_model
+
+print('training the baseline ...')
+baseline_model = Base_SegModel('TempOut.txt', average_morph_length)
+corpusweight = baseline_model._corpus_coding.weight
+print('using corpus weight {}'.format(corpusweight))
+
+def Base_Segmentation(segmodel, fl, output):
+    f = codecs.open(fl, 'r', encoding='utf-8')
+    fw = codecs.open(output, 'w', encoding='utf-8')
+    wordlist = []
+    for line in f:
+        lines = line.strip().split()
+        wordlist.append((line[0], lines[1]))
+    for count, word in wordlist:
+        seg = segmodel.viterbi_segment(word)
+        fw.write(count + ' ')
+        for i in range(len(seg[0])):
+            fw.write(seg[0][i])
+            if len(seg[0][i:]) > 1:
+                fw.write(' ' + '+' + ' ')
+        fw.write('\n')
+    return wordlist
+
+a = Base_Segmentation(baseline_model, 'Freq.txt', 'Seg_output.txt')
+
+print('training the stemming model ...')
+def ModelTraining(segmentation_file):
+    io = flatcat.FlatcatIO()
+    morph_usage = flatcat.categorizationscheme.MorphUsageProperties()
+    model = flatcat.FlatcatModel(morph_usage, corpusweight=corpusweight)
+    model.add_corpus_data(io.read_segmentation_file(segmentation_file))
+    model.initialize_hmm()
+    model.train_batch()
+    return model
+
+model = ModelTraining('Seg_output.txt')
+
+print('stemming ...')
+def Segment(files, model, output_path):
+    segdict = {}
+    for file in files:
+        seglist = []
+        fw = codecs.open(output_path + file, 'w', encoding='utf-8')
+        wordlist = files[file]
+        for word in wordlist:
+            ana = model.viterbi_analyze(word)
+            for construct in ana[0]:
+                if construct.category == 'STM':
+                    fw.write(construct.morph + ' ')
+                seglist.append(construct.morph)
+        segdict[file] = seglist
+    return segdict
+
+sg = Segment(files, model, output_dir)
+print('Finished!')

--- a/Stemming_unsupervised.py
+++ b/Stemming_unsupervised.py
@@ -7,20 +7,20 @@ import sys
 import morfessor
 import flatcat
 
-def filetowordlist(path, sfx, output, output_freq): 
+def filetowordlist(path, sfx, output, output_freq):
     filedict = {}
     allwordlist = []
-    fw = codecs.open(output, 'w', encoding = 'utf-8')
+    fw = codecs.open(output, 'w', encoding='utf-8')
     for item in os.listdir(path):
         if sfx in item:
             wordlist = []
-            for line in codecs.open(path+item, 'r', encoding = 'utf-8'):
+            for line in codecs.open(path+item, 'r', encoding='utf-8'):
                 lines = line.strip().split()
                 for word in lines:
                     wd = ''
                     for letter in word:
                         if letter.isalpha():
-                            wd = wd+letter 
+                            wd = wd+letter
                         else:
                             wd = wd + ' '
                     w = wd.split()
@@ -28,34 +28,34 @@ def filetowordlist(path, sfx, output, output_freq):
                         wordlist.append(d.lower())
                         allwordlist.append(d.lower())
                         fw.write(d.lower() + '\n')
-            filedict[item] = wordlist           
-    print 'counting word frequencies ...'
-    fw_freq = codecs.open(output_freq, 'w', encoding = 'utf-8')
+            filedict[item] = wordlist
+    print('counting word frequencies ...')
+    fw_freq = codecs.open(output_freq, 'w', encoding='utf-8')
     for word in set(allwordlist):
         fw_freq.write(str(allwordlist.count(word)) + ' ' + word + '\n')
     return filedict, allwordlist
-            
-print 'loading and preprocessing data ...'
+
+print('loading and preprocessing data ...')
 files, allwordlist = filetowordlist(sys.argv[1], '.txt', 'TempOut.txt', 'Freq.txt')
 
 def Base_SegModel(data):
     io = morfessor.MorfessorIO()
     train_data = list(io.read_corpus_file(data))
     model_types = morfessor.BaselineModel()
-    model_types.load_data(train_data, count_modifier = lambda x:1)
+    model_types.load_data(train_data, count_modifier=lambda x: 1)
     model_types.train_batch()
     model_tokens = morfessor.BaselineModel()
     model_tokens.load_data(train_data)
     model_tokens.train_batch()
-    
+
     return model_types, model_tokens
-    
-print 'training the baseline ...'
+
+print('training the baseline ...')
 segmentation_types, segmentation_tokens = Base_SegModel('TempOut.txt')
 
 def Base_Segmentation(segmodel, fl, output):
-    f = codecs.open(fl, 'r', encoding = 'utf-8')
-    fw = codecs.open(output, 'w', encoding = 'utf-8')
+    f = codecs.open(fl, 'r', encoding='utf-8')
+    fw = codecs.open(output, 'w', encoding='utf-8')
     wordlist = []
     for line in f:
         lines = line.strip().split()
@@ -63,33 +63,32 @@ def Base_Segmentation(segmodel, fl, output):
     for count, word in wordlist:
         seg = segmodel.viterbi_segment(word)
         fw.write(count + ' ')
-        opt = []
-        for i in xrange(len(seg[0])):
+        for i in range(len(seg[0])):
             fw.write(seg[0][i])
             if len(seg[0][i:]) > 1:
-                fw.write(' ' + '+' + ' ')  
+                fw.write(' ' + '+' + ' ')
         fw.write('\n')
     return wordlist
 
 a = Base_Segmentation(segmentation_tokens, 'Freq.txt', 'Seg_output.txt')
 
-print 'training the stemming model ...'
+print('training the stemming model ...')
 def ModelTraining(segmentation_file):
     io = flatcat.FlatcatIO()
     morph_usage = flatcat.categorizationscheme.MorphUsageProperties()
-    model = flatcat.FlatcatModel(morph_usage, corpusweight = 1.0)
+    model = flatcat.FlatcatModel(morph_usage, corpusweight=1.0)
     model.add_corpus_data(io.read_segmentation_file(segmentation_file))
     model.initialize_hmm()
     return model
-    
+
 model = ModelTraining('Seg_output.txt')
 
-print 'stemming ...'
+print('stemming ...')
 def Segment(files, model, output_path):
     segdict = {}
     for file in files:
         seglist = []
-        fw = codecs.open(output_path + file, 'w', encoding = 'utf-8')
+        fw = codecs.open(output_path + file, 'w', encoding='utf-8')
         wordlist = files[file]
         for word in wordlist:
             ana = model.viterbi_analyze(word)
@@ -101,9 +100,4 @@ def Segment(files, model, output_path):
     return segdict
 
 sg = Segment(files, model, sys.argv[2])
-print 'Finished!'
-    
-
-
-
-
+print('Finished!')


### PR DESCRIPTION
The command to train the Morfessor FlatCat model
`model.train_batch()` was missing.
This means that FlatCat was only used to tag the Morfessor Baseline segmentation, without resegmenting.

To get good performance from Morfessor, it is important to set the corpus weight parameter.
Therefore I also added the possibility to set the parameter from the command line,
and also made a separate script that uses the Morfessor auto-tuning system.